### PR TITLE
mpv: add subtitle position/scale controls and screenshot template/keybinding

### DIFF
--- a/.xmplayer/config/input.conf
+++ b/.xmplayer/config/input.conf
@@ -5,6 +5,10 @@ a cycle-values video-aspect-override "-1" "1:1" "4:3" "3:2" "16:9" "2.35:1"
 A cycle-values panscan 0.0 0.5 1.0
 v cycle audio
 O cycle-values osd-level 1 3
+Shift+UP add sub-pos -1
+Shift+DOWN add sub-pos 1
+Shift+LEFT add sub-scale -0.1
+Shift+RIGHT add sub-scale 0.1
 
 # Keyboard keys mapped by gptokeyb for Portmaster (xmplayer.gptk)
 ENTER cycle pause

--- a/.xmplayer/config/input.conf
+++ b/.xmplayer/config/input.conf
@@ -9,6 +9,7 @@ Shift+UP add sub-pos -1
 Shift+DOWN add sub-pos 1
 Shift+LEFT add sub-scale -0.1
 Shift+RIGHT add sub-scale 0.1
+P screenshot video
 
 # Keyboard keys mapped by gptokeyb for Portmaster (xmplayer.gptk)
 ENTER cycle pause

--- a/.xmplayer/config/mpv.conf
+++ b/.xmplayer/config/mpv.conf
@@ -16,3 +16,4 @@ osd-border-size=3
 osd-level=1                    
 osd-duration=3000
 
+screenshot-template="%xscreenshots/Screenshot-%F-T%wH.%wM.%wS.%wT-F%{estimated-frame-number}"


### PR DESCRIPTION
Adds mpv controls for manipulating subtitle view, plus a quick way to capture screenshots.

**Subtitle manipulation (input.conf)**

`Menu + UP` / `Menu + DOWN`: adjust sub-pos
`Menu + LEFT` / `Menu + RIGHT`: adjust sub-scale

**Screenshot support (input.conf + mpv.conf)**

- Adds the `Menu + A` keybinding to take a screenshot
- Sets `screenshot-template` to save screenshots with timestamps/track info under a `screenshots/` directory in the current video’s directory.